### PR TITLE
Fix missing quotes

### DIFF
--- a/docker-swarm-entrypoint.sh
+++ b/docker-swarm-entrypoint.sh
@@ -66,7 +66,7 @@ then
 
     su -c 'touch $ZOO_DYNAMIC_CONFIG_FILE' $ZOO_USER
 
-    if [[ -z REPLICAS ]]
+    if [[ -z $REPLICAS ]]
     then
         echo "REPLICAS not supplied."
         exit 1


### PR DESCRIPTION
Need to quote "$REPLICAS" when testing for zero string to avoid bash error when variable is not defined
